### PR TITLE
IceMetadatalessStCypressWriter sometimes passes down a symbol instead…

### DIFF
--- a/repository/GitMigration.package/GitMigrationMemoryStore.class/instance/pathFromString..st
+++ b/repository/GitMigration.package/GitMigrationMemoryStore.class/instance/pathFromString..st
@@ -1,8 +1,13 @@
 converting
 pathFromString: aString
-	| normalized |
+	| theString normalized |
+	"IceMetadatalessStCypressWriter sometimes passes down a symbol instead of a string.
+	Convert symbols to strings so the normalisation can be done."
+	theString := aString isSymbol
+		ifTrue: [ aString asString ]
+		ifFalse: [ aString ].
 	"Normalize both / to \ to the current one (so it works both on Unix and Windows)"
-	normalized := aString copy
+	normalized := theString copy
 		replaceAll: WindowsStore delimiter with: self delimiter;
 		replaceAll: UnixStore delimiter with: self delimiter.
 	^ super pathFromString: normalized


### PR DESCRIPTION
… of a string.

Convert symbols to strings so the normalisation can be done.