### PR TITLE
Added method to collect package users

### DIFF
--- a/repository/GitMigration.package/GitMigration.class/instance/collectPackageUsers..st
+++ b/repository/GitMigration.package/GitMigration.class/instance/collectPackageUsers..st
@@ -1,0 +1,15 @@
+accessing
+collectPackageUsers: packageName
+	" Collect and answer a <Collection> with the package users suitabe for use in #authors: parameter.
+	e-mails should be entered manually. "
+	
+	authors := ((RPackageOrganizer default packageNames 
+		select: [ : p | p beginsWith: packageName ]
+		thenCollect: [ : n | n asPackage methods collect: #author ])
+			gather: #yourself) asSet.
+	^ (authors 
+		reject: #isEmpty
+		thenCollect: [ : n | 
+			n -> (Array 
+				with: ((n piecesCutWhere: [ : a : b | b isUppercase ]) joinUsing: ' ')
+				with: '@.') ]) asSortedCollection.

--- a/repository/GitMigration.package/GitMigrationTest.class/instance/testCollectPackageUsers.st
+++ b/repository/GitMigration.package/GitMigrationTest.class/instance/testCollectPackageUsers.st
@@ -1,0 +1,13 @@
+tests - accessing
+testCollectPackageUsers
+
+	| pkgUsers gm |
+	gm := GitMigration new.
+	pkgUsers := gm collectPackageUsers: 'Kernel'.
+	self assert: (pkgUsers isKindOf: Collection).
+	self deny: pkgUsers isEmpty.
+	self assert: (pkgUsers first isKindOf: Association).
+	self deny: pkgUsers first key isEmpty.
+	self assert: (pkgUsers first value isKindOf: Collection).
+	self deny: pkgUsers first value isEmpty.
+	self assert: pkgUsers first value second equals: '@.'


### PR DESCRIPTION
Added method to collect package users in the format expected as parameter of GitMigration>>authors: method.

The #collectPackageUsers: receives a package name which will be matched against all RPackages in the image searched using beginsWith: . Then all author Strings of methods of every selected package are collected. The asSet removes duplicate author names. Finally another filter removes empty author names usually found in method annotations. Resulting collection is sorted for a better later edition and formatted as parameter of authors: method.
Addition of e-mails is required manually.

Added test